### PR TITLE
chore: use latest docker tag in docker:compose:demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A `docker-compose.yml` is included with the following services:
 -   `push-analytics`: The Push Analytics Service itself, with a configurable image tag
 -   `e2e`: A NodeJS service that runs the e2e test suite.
 
-The `docker` folder contains a custom `dhis2.conf` that enables user impersonation and increases the number of allowed user sessions, and a DB Dump for a database that fulfills all preconditions has been uploaded to the Push Analytics repo and will be used to create the DHIS2 Core service. Details of what has been added to the database are [documented here](docker/README.md)
+The `docker` folder contains a custom `dhis2.conf` that enables user impersonation and increases the number of allowed user sessions, and a DB Dump for a database that fulfills all preconditions has been uploaded to the Push Analytics repo and will be used to create the DHIS2 Core service. Details of what has been added to the database are [documented here](docker/DB.md)
 
 Note that, by default, `docker compose` will look for a file called `.env` to source its environment variables, however, the `.env` file in the Push Analytics repo serves a different purpose ([as explained here](#environment-variables)). Instead, the `.env.e2e` file is meant to be used for docker compose, and as a result all docker compose commands will need to specify which environment file to use, i.e. `docker compose --env-file ./.env.e2e up [..]`.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "test:e2e:watch": "npx tsc -p ./tsconfig.e2e.json --noEmit && HOST=http://localhost PORT=1337 TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true node --test --watch --test-reporter spec --require ts-node/register $(find ./e2e -name '*.e2e.ts')",
         "docker:build:local": "docker build -t dhis2/push-analytics:local .",
         "docker:compose:dev": "docker compose --env-file ./.env.e2e up -d web db db-dump post-install-scripts",
-        "docker:compose:demo": "PUSH_ANALYTICS_IMAGE=dhis2/push-analytics:1.0.0-alpha.4 docker compose --env-file ./.env.e2e up -d web db db-dump fake-smtp-server post-install-scripts push-analytics",
+        "docker:compose:demo": "PUSH_ANALYTICS_IMAGE=dhis2/push-analytics:latest docker compose --env-file ./.env.e2e up -d web db db-dump fake-smtp-server post-install-scripts push-analytics",
         "db-dump:default": "pg_dump postgresql://dhis:dhis@localhost:5432/dhis -T 'analytics*' -T '_*' -T 'rs_*' | gzip >dump.sql.gz",
         "db-dump:with-analytics": "pg_dump 'postgresql://dhis:dhis@localhost:5432/dhis' | gzip >dump_with_analytics.sql.gz",
         "start:dev": "nodemon --exec ts-node -r dotenv/config src/index.ts",


### PR DESCRIPTION
I'm going to be using my admin permissions to merge this one. This PR only updates a link in the readme and ensures the `docker:compose:demo` uses a valid docker tag.