### PR TITLE
chore: address issues with the E2E setup in GHA

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,5 +1,5 @@
 DHIS2_IMAGE="dhis2/core:2.41"
-DHIS2_DB_DUMP_URL="https://github.com/dhis2/push-analytics/releases/download/1.0.1/PUSH_ANALYTICS_41_2025_DUMP_MEASLES_TWEAK.sql.gz"
+DHIS2_DB_DUMP_URL="https://github.com/dhis2/push-analytics/releases/download/1.0.4/dump.sql.gz"
 FAKESMTP_AUTHENTICATION_USERNAME=myuser
 FAKESMTP_AUTHENTICATION_PASSWORD=mysecretpassword
 FAKESMTP_PORT=8030

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -21,18 +21,21 @@ jobs:
               run: docker compose --env-file .env.e2e up -d web db db-dump post-install-scripts push-analytics
             - name: Run the e2e test suite
               run: docker compose --env-file .env.e2e up --abort-on-container-exit --exit-code-from e2e e2e
-            - name: Copy scrape markdown logs to runner
+            - name: Copy scrape markdown logs and generated HTML to runner
               if: ${{ failure() }}
               run: |
-                  mkdir scrape-markdown-logs
-                  container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
-                  docker cp ${container_id}:/usr/src/app/scrape-markdown-logs ./scrape-markdown-logs
-            - name: Store scrape markdown logs as a GHA artefact
+                  mkdir e2e-output
+                  mkdir e2e-output/scrape-markdown-logs
+                  mkdir e2e-output/generated-html
+                  pa_container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
+                  docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output
+                  cp -r ./e2e/generated-html ./e2e-output
+            - name: Store scrape markdown logs and generated HTML as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4
               with:
-                  name: scrape-markdown-logs
-                  path: scrape-markdown-logs/
+                  name: e2e-failure-output
+                  path: e2e-output/
 
     send-slack-message:
         runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -63,7 +63,7 @@ jobs:
                   mkdir e2e-output/generated-html
                   pa_container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
                   docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output/scrape-markdown-logs
-                  mv ./e2e/generated-html ./e2e-output/generated-html
+                  cp ./e2e/generated-html ./e2e-output/generated-html
             - name: Store scrape markdown logs and generated HTML as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -62,9 +62,8 @@ jobs:
                   mkdir e2e-output/scrape-markdown-logs
                   mkdir e2e-output/generated-html
                   pa_container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
-                  e2e_container_id="$(docker compose --env-file .env.e2e ps -q e2e)"
                   docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output/scrape-markdown-logs
-                  docker cp ${e2e_container_id}:/opt/app/generated-html ./e2e-output/generated-html
+                  mv ./e2e/generated-html ./e2e-output/generated-html
             - name: Store scrape markdown logs and generated HTML as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -63,7 +63,7 @@ jobs:
                   mkdir e2e-output/generated-html
                   pa_container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
                   docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output/scrape-markdown-logs
-                  cp ./e2e/generated-html ./e2e-output/generated-html
+                  cp -r ./e2e/generated-html ./e2e-output/generated-html
             - name: Store scrape markdown logs and generated HTML as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -55,12 +55,13 @@ jobs:
               run: docker compose --env-file .env.e2e up -d web db db-dump post-install-scripts push-analytics
             - name: Run the e2e test suite
               run: docker compose --env-file .env.e2e up --abort-on-container-exit --exit-code-from e2e e2e
-            - name: Copy scrape markdown logs to runner
+            - name: Copy scrape markdown logs and produced fixtures to runner
               if: ${{ failure() }}
               run: |
                   mkdir scrape-markdown-logs
                   container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
                   docker cp ${container_id}:/usr/src/app/scrape-markdown-logs ./scrape-markdown-logs
+                  docker cp ${container_id}:/usr/src/app/e2e/__fixtures__ ./scrape-markdown-logs/actual-html
             - name: Store scrape markdown logs as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -55,16 +55,19 @@ jobs:
               run: docker compose --env-file .env.e2e up -d web db db-dump post-install-scripts push-analytics
             - name: Run the e2e test suite
               run: docker compose --env-file .env.e2e up --abort-on-container-exit --exit-code-from e2e e2e
-            - name: Copy scrape markdown logs and produced fixtures to runner
+            - name: Copy scrape markdown logs and generated HTML to runner
               if: ${{ failure() }}
               run: |
-                  mkdir scrape-markdown-logs
-                  container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
-                  docker cp ${container_id}:/usr/src/app/scrape-markdown-logs ./scrape-markdown-logs
-                  docker cp ${container_id}:/usr/src/app/e2e/__fixtures__ ./scrape-markdown-logs/actual-html
-            - name: Store scrape markdown logs as a GHA artefact
+                  mkdir e2e-output
+                  mkdir e2e-output/scrape-markdown-logs
+                  mkdir e2e-output/generated-html
+                  pa_container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
+                  e2e_container_id="$(docker compose --env-file .env.e2e ps -q e2e)"
+                  docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output/scrape-markdown-logs
+                  docker cp ${e2e_container_id}:/opt/app/generated-html ./e2e-output/generated-html
+            - name: Store scrape markdown logs and generated HTML as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4
               with:
-                  name: scrape-markdown-logs
-                  path: scrape-markdown-logs/
+                  name: e2e-failure-output
+                  path: e2e-output/

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -62,8 +62,8 @@ jobs:
                   mkdir e2e-output/scrape-markdown-logs
                   mkdir e2e-output/generated-html
                   pa_container_id="$(docker compose --env-file .env.e2e ps -q push-analytics)"
-                  docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output/scrape-markdown-logs
-                  cp -r ./e2e/generated-html ./e2e-output/generated-html
+                  docker cp ${pa_container_id}:/usr/src/app/scrape-markdown-logs ./e2e-output
+                  cp -r ./e2e/generated-html ./e2e-output
             - name: Store scrape markdown logs and generated HTML as a GHA artefact
               if: ${{ failure() }}
               uses: actions/upload-artifact@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,7 @@ services:
         environment:
             - HOST=${HOST}
             - PORT=${PORT}
+            - DHIS2_IMAGE=${DHIS2_IMAGE}
         command: >
             sh -c "npm install npm@latest -g &&
                    npm ci --yes --ignore-scripts --include=dev &&

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -42,7 +42,7 @@ describe('converting all types of dashboard items', () => {
         const similarity = stringSimilarity.compareTwoStrings(actualHtml, expectedHtml)
         console.log(`Actual and expected string are ${similarity * 100}% similar`)
         if (similarity <= 0.8) {
-            fs.writeFileSync(filePath, actualHtml)
+            fs.writeFileSync(path.resolve('./generated-html'), actualHtml)
         }
         assert.strictEqual(similarity > 0.8, true)
     })

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -4,12 +4,10 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import stringSimilarity from 'string-similarity'
 import request from 'supertest'
-import { getFixtureDir } from './utils'
+import { assertEnv, getFixtureDir } from './utils'
 
 describe('converting all types of dashboard items', () => {
-    if (!process.env.HOST || !process.env.PORT) {
-        throw new Error('HOST and PORT env variables missing, aborting test run')
-    }
+    assertEnv()
     const url = `${process.env.HOST}:${process.env.PORT}`
     const fixturesPath = getFixtureDir()
 

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -9,7 +9,7 @@ import { assertEnv, getFixtureDir } from './utils'
 describe('converting all types of dashboard items', () => {
     assertEnv()
     const url = `${process.env.HOST}:${process.env.PORT}`
-    const fixturesPath = getFixtureDir()
+    const fixturesPath = getFixtureDir(process.env.DHIS2_IMAGE)
 
     console.log(`Running tests agains URL "${url}"`)
 

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -42,7 +42,10 @@ describe('converting all types of dashboard items', () => {
         const similarity = stringSimilarity.compareTwoStrings(actualHtml, expectedHtml)
         console.log(`Actual and expected string are ${similarity * 100}% similar`)
         if (similarity <= 0.8) {
-            fs.writeFileSync(path.resolve('./e2e/generated-html'), actualHtml)
+            fs.writeFileSync(
+                path.resolve('./e2e/generated-html', `${dashboardId}_${username}.html`),
+                actualHtml
+            )
         }
         assert.strictEqual(similarity > 0.8, true)
     })

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -9,7 +9,7 @@ import { assertEnv, getFixtureDir } from './utils'
 describe('converting all types of dashboard items', () => {
     assertEnv()
     const url = `${process.env.HOST}:${process.env.PORT}`
-    const fixturesPath = getFixtureDir(process.env.DHIS2_IMAGE)
+    const fixtureDir = getFixtureDir(process.env.DHIS2_IMAGE)
 
     console.log(`Running tests agains URL "${url}"`)
 
@@ -18,7 +18,7 @@ describe('converting all types of dashboard items', () => {
         const dashboardId = 'ceneQPMhemM'
         const username = 'test_user_national'
         const locale = 'en'
-        const filePath = path.resolve(fixturesPath, `${dashboardId}_${username}.txt`)
+        const filePath = path.resolve(fixtureDir, `${dashboardId}_${username}.txt`)
         const expectedHtml = fs.readFileSync(filePath).toString()
         const response = await req.get('/').query({ dashboardId, username, locale })
 

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -42,7 +42,7 @@ describe('converting all types of dashboard items', () => {
         const similarity = stringSimilarity.compareTwoStrings(actualHtml, expectedHtml)
         console.log(`Actual and expected string are ${similarity * 100}% similar`)
         if (similarity <= 0.8) {
-            fs.writeFileSync(path.resolve('./generated-html'), actualHtml)
+            fs.writeFileSync(path.resolve('./e2e/generated-html'), actualHtml)
         }
         assert.strictEqual(similarity > 0.8, true)
     })

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -4,7 +4,7 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import stringSimilarity from 'string-similarity'
 import request from 'supertest'
-import { assertEnv, getFixtureDir } from './utils'
+import { assertEnv, getFixtureDir, saveActualHtml } from './utils'
 
 describe('converting all types of dashboard items', () => {
     test('ensure the expected env vars are in place', () => {
@@ -42,10 +42,7 @@ describe('converting all types of dashboard items', () => {
         const similarity = stringSimilarity.compareTwoStrings(actualHtml, expectedHtml)
         console.log(`Actual and expected string are ${similarity * 100}% similar`)
         if (similarity <= 0.8) {
-            fs.writeFileSync(
-                path.resolve('./e2e/generated-html', `${dashboardId}_${username}.html`),
-                actualHtml
-            )
+            saveActualHtml(`${dashboardId}_${username}.html`, actualHtml)
         }
         assert.strictEqual(similarity > 0.8, true)
     })

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -41,6 +41,9 @@ describe('converting all types of dashboard items', () => {
          * are showing.*/
         const similarity = stringSimilarity.compareTwoStrings(actualHtml, expectedHtml)
         console.log(`Actual and expected string are ${similarity * 100}% similar`)
+        if (similarity <= 0.8) {
+            fs.writeFileSync(filePath, actualHtml)
+        }
         assert.strictEqual(similarity > 0.8, true)
     })
 })

--- a/e2e/dashboardItemTypes.e2e.ts
+++ b/e2e/dashboardItemTypes.e2e.ts
@@ -7,7 +7,9 @@ import request from 'supertest'
 import { assertEnv, getFixtureDir } from './utils'
 
 describe('converting all types of dashboard items', () => {
-    assertEnv()
+    test('ensure the expected env vars are in place', () => {
+        assertEnv()
+    })
     const url = `${process.env.HOST}:${process.env.PORT}`
     const fixtureDir = getFixtureDir(process.env.DHIS2_IMAGE)
 

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -4,12 +4,10 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import stringSimilarity from 'string-similarity'
 import request from 'supertest'
-import { getFixtureDir } from './utils'
+import { assertEnv, getFixtureDir } from './utils'
 
 describe('producing user specific dashboard content', () => {
-    if (!process.env.HOST || !process.env.PORT) {
-        throw new Error('HOST and PORT env variables missing, aborting test run')
-    }
+    assertEnv()
     const url = `${process.env.HOST}:${process.env.PORT}`
     console.log(`Running tests agains URL "${url}"`)
     const fixtureDir = getFixtureDir()

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -57,7 +57,7 @@ describe('producing user specific dashboard content', () => {
             )
             console.log(`Actual and expected string are ${similarity * 100}% similar`)
             if (similarity <= 0.8) {
-                fs.writeFileSync(filePath, actualHtml)
+                fs.writeFileSync(path.resolve('./generated-html'), actualHtml)
             }
             assert.strictEqual(similarity > 0.8, true)
         })

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -7,7 +7,9 @@ import request from 'supertest'
 import { assertEnv, getFixtureDir } from './utils'
 
 describe('producing user specific dashboard content', () => {
-    assertEnv()
+    test('ensure the expected env vars are in place', () => {
+        assertEnv()
+    })
     const url = `${process.env.HOST}:${process.env.PORT}`
     console.log(`Running tests agains URL "${url}"`)
     const fixtureDir = getFixtureDir(process.env.DHIS2_IMAGE)

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -57,7 +57,13 @@ describe('producing user specific dashboard content', () => {
             )
             console.log(`Actual and expected string are ${similarity * 100}% similar`)
             if (similarity <= 0.8) {
-                fs.writeFileSync(path.resolve('./e2e/generated-html'), actualHtml)
+                fs.writeFileSync(
+                    path.resolve(
+                        './e2e/generated-html/',
+                        `${dashboardId}_${username}.html`
+                    ),
+                    actualHtml
+                )
             }
             assert.strictEqual(similarity > 0.8, true)
         })

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -4,7 +4,7 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 import stringSimilarity from 'string-similarity'
 import request from 'supertest'
-import { assertEnv, getFixtureDir } from './utils'
+import { assertEnv, getFixtureDir, saveActualHtml } from './utils'
 
 describe('producing user specific dashboard content', () => {
     test('ensure the expected env vars are in place', () => {
@@ -57,13 +57,7 @@ describe('producing user specific dashboard content', () => {
             )
             console.log(`Actual and expected string are ${similarity * 100}% similar`)
             if (similarity <= 0.8) {
-                fs.writeFileSync(
-                    path.resolve(
-                        './e2e/generated-html/',
-                        `${dashboardId}_${username}.html`
-                    ),
-                    actualHtml
-                )
+                saveActualHtml(`${dashboardId}_${username}.html`, actualHtml)
             }
             assert.strictEqual(similarity > 0.8, true)
         })

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -56,6 +56,9 @@ describe('producing user specific dashboard content', () => {
                 expectedHtml
             )
             console.log(`Actual and expected string are ${similarity * 100}% similar`)
+            if (similarity <= 0.8) {
+                fs.writeFileSync(filePath, actualHtml)
+            }
             assert.strictEqual(similarity > 0.8, true)
         })
     }

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -10,7 +10,7 @@ describe('producing user specific dashboard content', () => {
     assertEnv()
     const url = `${process.env.HOST}:${process.env.PORT}`
     console.log(`Running tests agains URL "${url}"`)
-    const fixtureDir = getFixtureDir()
+    const fixtureDir = getFixtureDir(process.env.DHIS2_IMAGE)
     const fixturesPath = path.resolve('./e2e/__fixtures__', fixtureDir)
     const req = request(url)
     const dashboardId = 'KQVXh5tlzW2'

--- a/e2e/userSpecificDashboardContent.e2e.ts
+++ b/e2e/userSpecificDashboardContent.e2e.ts
@@ -57,7 +57,7 @@ describe('producing user specific dashboard content', () => {
             )
             console.log(`Actual and expected string are ${similarity * 100}% similar`)
             if (similarity <= 0.8) {
-                fs.writeFileSync(path.resolve('./generated-html'), actualHtml)
+                fs.writeFileSync(path.resolve('./e2e/generated-html'), actualHtml)
             }
             assert.strictEqual(similarity > 0.8, true)
         })

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,12 +1,15 @@
 import path from 'node:path'
+import assert from 'node:assert'
 
-export function getFixtureDir() {
-    if (!process.env.DHIS2_IMAGE) {
-        throw new Error(
-            'Ensure DHIS2_IMAGE is set before running these tests, because the fixtures are version specific'
-        )
-    }
-    const imageTagDir = process.env.DHIS2_IMAGE.replace('dhis2/', '')
+export function assertEnv() {
+    assert.ok(process.env.HOST)
+    assert.ok(process.env.PORT)
+    assert.ok(process.env.DHIS2_IMAGE)
+}
+
+export function getFixtureDir(dhis2ImageTag = '') {
+    const imageTagDir = dhis2ImageTag
+        .replace('dhis2/', '')
         .replace(':', '_')
         .replace('.', '-')
     const fixturesPath = path.resolve('./e2e/__fixtures__', imageTagDir)

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import assert from 'node:assert'
+import fs from 'node:fs'
 
 export function assertEnv() {
     assert.ok(process.env.HOST)
@@ -17,4 +18,12 @@ export function getFixtureDir(dhis2ImageTag = '') {
     console.log(`Using fixtures from "${fixturesPath}"`)
 
     return fixturesPath
+}
+
+export function saveActualHtml(fileName: string, actualHtml: string) {
+    const dir = path.resolve('./e2e/generated-html')
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir)
+    }
+    fs.writeFileSync(path.resolve(dir, fileName), actualHtml)
 }


### PR DESCRIPTION
This PR addresses two problems that are only loosely related:

### Failing the E2E job properly
In a previous PR https://github.com/dhis2/push-analytics/pull/72 I introduced "version specific fixtures". This relies on the presence of the `DHIS2_IMAGE` env variable. To ensure this variable was indeed available, I was doing a check and throwing an error. There was some pre-existing code that was doing the same for `HOST` and `PORT`.

As it turns out, this is not a good approach at all. When the error is thrown the container exits, but the error code with which it exits is `0` and this signals to the GHA runner that the job has completed successfully. SO THIS WAS PRETTY BAD.

Since failing tests do make the job fail with the correct exit code `1`, I decided to implement these env variable checks as a test. I have been able to verify [this works as expected](https://github.com/dhis2/push-analytics/actions/runs/15250927020/job/42887502014?pr=73).

###  Ensuring the `DHIS2_IMAGE` env var is available to the E2E docker compose service
The `DHIS2_IMAGE` variable was being provided to the GHA workflow and to the Docker Compose file, but I had forgotten to actually pass it to the E2E docker compose service. This has now been addressed in [8579790](https://github.com/dhis2/push-analytics/pull/73/commits/85797906a14ca55cd3c59f36dec4ae45066bf466)